### PR TITLE
Require Raku 6.d as a minimum requirement

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,5 +1,5 @@
 {
-    "perl"        : "6.c",
+    "perl"        : "6.d",
     "name"        : "Pod::To::HTML",
     "version"     : "0.7.1",
     "auth"        : "github:Raku",


### PR DESCRIPTION
This requirement should help avoid old language versions trying to run
code written in a more recent language version and thus also avoid
unnecessary build errors on e.g. Travis etc.

See #58 as well as https://github.com/Raku/examples/issues/53 for more
details.