### PR TITLE
move Test::Output to "test-depends"

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -9,7 +9,9 @@
     "depends"     : [
         "URI",
         "Template::Mustache",
-        "Pod::Load:ver<0.4.0+>",
+        "Pod::Load:ver<0.4.0+>"
+    ],
+    "test-depends": [
         "Test::Output"
     ],
     "provides"     : {


### PR DESCRIPTION
Test::Output is used only in `t/120-templates.t`.
So I don't think we should list it as "depends".