### PR TITLE
Support concurrency

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -9,7 +9,8 @@
     "depends"     : [
         "URI",
         "Template::Mustache",
-        "Pod::Load:ver<0.4.0+>"
+        "Pod::Load:ver<0.4.0+>",
+        "OO::Monitors"
     ],
     "test-depends": [
         "Test::Output"

--- a/lib/Pod/To/HTML.pm6
+++ b/lib/Pod/To/HTML.pm6
@@ -74,8 +74,8 @@ class Pod::To::HTML {
             die $! if $counter++ == 5;
             my $result = try Template::Mustache.new.render($content, %context, :from[%partials], :literal);
             with $! {
-                warn "An error occurred when rendering [$title-html], retrying, $counter times left, original message: \n" ~ $!
-                .message;
+                warn "An error occurred when rendering [$title-html], retrying, $counter times left, original message: \n"
+                        ~ $!.message;
             } else {
                 return $result;
             }


### PR DESCRIPTION
So I did a bit of investigation for https://github.com/Raku/Pod-To-HTML/issues/63...

It seems `find-headings` is unsafe, so made it into a method and protected with monitor. ??? Problem is gone.

It seems `Template::Mustache` triggers some rakudo/moar(?) issue as well, as it refused to compile some pages (usually 5 plus-minus a couple from the whole documentation, always different ones) with a bogus error (`self being null`). So created a special loop catching issues doing some retries. It fixed the problem I saw. By the way, `Cro::WebApp` tested had no issues like this one and was on average 2.5x to 5x times faster, but to use it we need a smooth API at hand.

Did some crunching with 24 threads rendering whole documentation 100 times in a row. In three crunch sessions saw a moarvm bug once, which is, I suspect, known and so very obscure we probably don't want to deal with it here (I saw it reported in different places).

Otherwise, it became **a lot** more stable unless you really stresstest it, so I believe the ticket can be closed.