### PR TITLE
Enable instance-less call to `render` method

### DIFF
--- a/lib/Pod/To/HTML.pm6
+++ b/lib/Pod/To/HTML.pm6
@@ -40,6 +40,9 @@ class Pod::To::HTML {
 
     #| Converts a Pod tree to a HTML document using templates
     method render($pod, TOC::Calculator :$toc = TOC::Calculator, :&url = -> $url { $url }) {
+        unless self {
+            return Pod::To::HTML.new.render($pod);
+        }
         # Keep count of how many footnotes we've output.
         my Int $*done-notes = 0;
         &!url = &url;


### PR DESCRIPTION
Fixes `--doc=HTML` usage. Closes https://github.com/Raku/Pod-To-HTML/issues/86