### PR TITLE
Pass config of a named paragraph to renderer

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
     "perl"        : "6.d",
     "name"        : "Pod::To::HTML",
-    "version"     : "0.8",
+    "version"     : "0.8.1",
     "auth"        : "github:Raku",
     "authors"     : [ "Raku" ],
     "description" : "Convert Raku Pod to HTML",

--- a/lib/Pod/To/HTML.pm6
+++ b/lib/Pod/To/HTML.pm6
@@ -270,7 +270,7 @@ monitor Node::To::HTML {
                 if $node.config<class>;
                 return self.node2html($node.contents);
             }
-            when 'para' { return self.node2html($node.contents[0]); }
+            when 'para' { return self.node2html($node.contents[0], |$node.config); }
             when 'Image' {
                 my $url;
                 if $node.contents == 1 {

--- a/t/140-config.t
+++ b/t/140-config.t
@@ -1,0 +1,25 @@
+use Pod::To::HTML;
+use Test;
+
+=begin pod
+
+=begin para :property<cool>
+Test text!
+=end para
+
+=end pod
+
+class Node::To::HTML::Custom is Node::To::HTML {
+    multi method node2html(Pod::Block::Para $node, *%config --> Str) {
+        with %config<property> {
+            "Nice, $_ render!";
+        } else {
+            "A bug appeared...";
+        }
+    }
+}
+
+like Pod::To::HTML.new(node-renderer => Node::To::HTML::Custom).render($=pod),
+        /'Nice, cool render!'/, 'Config in a paragraph was understood';
+
+done-testing;


### PR DESCRIPTION
Pod paragraph in named blocks can be flexibly configured, but
a paragraph renderer won't see the config of its parent the way it
is not passed now.

We probably have to do this everywhere, but lazy evaluation of
such cases is likely a better idea to avoid clutter and rapid perf bumps.

This is a second step of https://github.com/Raku/doc/pull/3693