### PR TITLE
Provide a way to specify custom HTML renderers, plus fix a buglet

### DIFF
--- a/lib/Pod/To/HTML.pm6
+++ b/lib/Pod/To/HTML.pm6
@@ -71,7 +71,7 @@ class Pod::To::HTML {
     #| Converts a Pod tree to a HTML document using templates
     method render($pod, TOC::Calculator :$toc = TOC::Calculator, :&url = -> $url { $url }) {
         unless self {
-            return Pod::To::HTML.new.render($pod);
+            return Pod::To::HTML.new.render($pod, :$toc);
         }
         # Keep count of how many footnotes we've output.
         my Int $*done-notes = 0;

--- a/t/120-templates.t
+++ b/t/120-templates.t
@@ -1,7 +1,7 @@
 use Test; # -*- mode: perl6 -*- 
 use Test::Output;
 use Pod::To::HTML;
-plan 5;
+plan 6;
 my $r;
 
 =begin pod
@@ -43,3 +43,12 @@ my $head='<meta name=viewport content="width=device-width, initial-scale=1">';
 $r = pod2html $=pod[0], :templates("t/templates"), :$head ;
 ok $r ~~ ms[[ $head ]], 'headers are redered as is';
 
+class Pod::To::HTML::Dummy does Pod::To::HTML::Renderer {
+    method render(%context) {
+        "Rendered %context<title>";
+    }
+}
+
+$r = pod2html $=pod[0], :page-renderer(Pod::To::HTML::Dummy);
+
+is $r, 'Rendered The usual suspects', 'Custom renderer was used';


### PR DESCRIPTION
Fixes https://github.com/Raku/Pod-To-HTML/issues/82

As for testing: the tests passing is already a sign it is ok, giving I am using Cro::WebApp it seems just fine enough. I am pretty reluctant to make Cro::WebApp a dependency just to make a test for it, maybe a simple stub would be a better idea.