### PR TITLE
Don't escape CSS

### DIFF
--- a/resources/templates/main.mustache
+++ b/resources/templates/main.mustache
@@ -3,7 +3,7 @@
 <head>
     <title>{{{title}}}</title>
     <meta charset="UTF-8"/>
-    <style>{{default-style}}</style>
+    <style>{{{default-style}}}</style>
 
     {{#css}}<link rel="stylesheet" href="{{css}}">{{/css}}
 </head>


### PR DESCRIPTION
Escaping CSS with HTML entities breaks the `"` quotes and `>` child selectors